### PR TITLE
feat(gluetun): adds a speedtest action

### DIFF
--- a/charms/gluetun-k8s/charmcraft.yaml
+++ b/charms/gluetun-k8s/charmcraft.yaml
@@ -29,6 +29,16 @@ parts:
     build-packages: [git]
     build-snaps: [astral-uv]
 
+  librespeed-cli:
+    plugin: dump
+    source: https://github.com/librespeed/speedtest-cli/releases/download/v1.0.12/librespeed-cli_1.0.12_linux_amd64.tar.gz
+    source-type: tar
+    source-checksum: sha256/78bf5cd10fc00006224efb82f5767b95ba414a7ca4dc315a7ed2b774ed80813c
+    organize:
+      librespeed-cli: bin/librespeed-cli
+    stage: [bin/librespeed-cli]
+    prime: [bin/librespeed-cli]
+
 containers:
   gluetun:
     resource: gluetun-image
@@ -135,4 +145,27 @@ config:
         to port 53 on all interfaces, conflicting with pod-gateway's dnsmasq
         which binds to the VXLAN interface (172.16.0.1:53). This causes bind
         errors and connection instability. Keep disabled.
+
+actions:
+  speedtest:
+    description: |
+      Run a LibreSpeed throughput test through the active VPN tunnel.
+
+      Uses the bundled librespeed-cli binary, executed inside the gluetun
+      container so the test traverses the VPN. Returns download/upload speeds
+      in Mbps along with ping and jitter in milliseconds.
+    params:
+      server-id:
+        type: integer
+        description: |
+          Optional LibreSpeed server ID. If unset, the closest server is
+          auto-selected from libreSpeed.org's public server list.
+      duration:
+        type: integer
+        default: 15
+        description: Per-direction test duration in seconds.
+      timeout:
+        type: integer
+        default: 30
+        description: HTTP request timeout in seconds.
 

--- a/charms/gluetun-k8s/src/_speedtest.py
+++ b/charms/gluetun-k8s/src/_speedtest.py
@@ -1,0 +1,130 @@
+# Copyright 2025 The Charmarr Project
+# See LICENSE file for licensing details.
+
+"""LibreSpeed speedtest action handler.
+
+Runs the bundled librespeed-cli binary inside the gluetun container so the
+test traverses the VPN tunnel. The binary is pushed lazily into /tmp on first
+invocation and reused until the pod is recreated.
+"""
+
+import json
+import logging
+import pathlib
+from typing import Any
+
+import ops
+from ops.pebble import ExecError
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+LIBRESPEED_BINARY_SRC = pathlib.Path(__file__).parent.parent / "bin" / "librespeed-cli"
+LIBRESPEED_BINARY_DEST = "/tmp/librespeed-cli"
+
+EXEC_TIMEOUT_OVERHEAD = 30
+
+
+class LibrespeedServer(BaseModel):
+    """Server selected for the test."""
+
+    name: str = ""
+    url: str = ""
+
+
+class LibrespeedResult(BaseModel):
+    """Single librespeed-cli JSON result entry."""
+
+    server: LibrespeedServer = Field(default_factory=LibrespeedServer)
+    bytes_sent: int = 0
+    bytes_received: int = 0
+    ping: float = 0.0
+    jitter: float = 0.0
+    upload: float = 0.0
+    download: float = 0.0
+
+
+def _ensure_binary_pushed(container: ops.Container) -> None:
+    """Push the librespeed-cli binary into the container if not already present."""
+    if container.exists(LIBRESPEED_BINARY_DEST):
+        return
+    with LIBRESPEED_BINARY_SRC.open("rb") as f:
+        container.push(LIBRESPEED_BINARY_DEST, f, permissions=0o755, make_dirs=True)
+    logger.info("Pushed librespeed-cli to %s", LIBRESPEED_BINARY_DEST)
+
+
+def _build_command(server_id: int | None, duration: int, timeout: int) -> list[str]:
+    """Build the librespeed-cli argv. ICMP ping is disabled (unreliable on Linux)."""
+    cmd = [
+        LIBRESPEED_BINARY_DEST,
+        "--json",
+        "--no-icmp",
+        "--duration",
+        str(duration),
+        "--timeout",
+        str(timeout),
+    ]
+    if server_id is not None:
+        cmd.extend(["--server", str(server_id)])
+    return cmd
+
+
+def _format_result(result: LibrespeedResult) -> dict[str, Any]:
+    """Map a parsed librespeed result into action result keys."""
+    return {
+        "download-mbps": result.download,
+        "upload-mbps": result.upload,
+        "ping-ms": result.ping,
+        "jitter-ms": result.jitter,
+        "bytes-sent": result.bytes_sent,
+        "bytes-received": result.bytes_received,
+        "server-name": result.server.name,
+        "server-url": result.server.url,
+    }
+
+
+def _parse_output(output: str) -> LibrespeedResult:
+    """Parse librespeed-cli --json output (a JSON array with one entry)."""
+    payload = json.loads(output)
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("librespeed-cli returned no results")
+    return LibrespeedResult.model_validate(payload[0])
+
+
+def handle_speedtest(event: ops.ActionEvent, container: ops.Container) -> None:
+    """Run a LibreSpeed test inside the gluetun container and set action results."""
+    if not container.can_connect():
+        event.fail("Cannot connect to gluetun container")
+        return
+
+    server_id = event.params.get("server-id")
+    duration = int(event.params.get("duration", 15))
+    timeout = int(event.params.get("timeout", 30))
+
+    try:
+        _ensure_binary_pushed(container)
+    except OSError as e:
+        event.fail(f"Failed to push librespeed-cli into container: {e}")
+        return
+
+    cmd = _build_command(server_id, duration, timeout)
+    # Allow for two test phases (download + upload) plus startup overhead.
+    exec_timeout = float(duration * 2 + timeout + EXEC_TIMEOUT_OVERHEAD)
+
+    try:
+        process = container.exec(cmd, timeout=exec_timeout)
+        output, _ = process.wait_output()
+    except ExecError as e:
+        event.fail(f"librespeed-cli failed (exit {e.exit_code}): {e.stderr or e.stdout}")
+        return
+    except TimeoutError:
+        event.fail(f"librespeed-cli timed out after {exec_timeout}s")
+        return
+
+    try:
+        result = _parse_output(output)
+    except (json.JSONDecodeError, ValueError) as e:
+        event.fail(f"Failed to parse librespeed-cli output: {e}")
+        return
+
+    event.set_results(_format_result(result))

--- a/charms/gluetun-k8s/src/charm.py
+++ b/charms/gluetun-k8s/src/charm.py
@@ -17,6 +17,7 @@ from ops.pebble import Layer
 from pydantic import BaseModel
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from _speedtest import handle_speedtest
 from charmarr_lib.core import K8sResourceManager, observe_events, reconcilable_events_k8s
 from charmarr_lib.vpn import (
     ISTIO_ZTUNNEL_LINK_LOCAL,
@@ -58,6 +59,7 @@ class GluetunCharm(ops.CharmBase):
 
         observe_events(self, reconcilable_events_k8s, self._reconcile)
         framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+        framework.observe(self.on.speedtest_action, self._on_speedtest_action)
 
     @property
     def k8s(self) -> K8sResourceManager:
@@ -414,6 +416,19 @@ class GluetunCharm(ops.CharmBase):
             input_cidrs=[],  # gluetun handles INPUT rules via post-rules.txt
         )
         self._vpn_gateway.publish_data(provider_data)
+
+    def _on_speedtest_action(self, event: ops.ActionEvent) -> None:
+        """Run a LibreSpeed throughput test through the VPN tunnel."""
+        if not self.unit.is_leader():
+            event.fail("Run on the leader unit (only the leader operates the VPN)")
+            return
+        if self._validate_config():
+            event.fail("Charm is misconfigured; resolve config before running speedtest")
+            return
+        if not self._check_vpn_health().connected:
+            event.fail("VPN is not connected; speedtest would be blocked by the kill switch")
+            return
+        handle_speedtest(event, self._container)
 
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
         """Collect all unit statuses without early returns.

--- a/charms/gluetun-k8s/tests/unit/test_speedtest.py
+++ b/charms/gluetun-k8s/tests/unit/test_speedtest.py
@@ -1,0 +1,171 @@
+# Copyright 2025 The Charmarr Project
+# See LICENSE file for licensing details.
+
+"""Unit tests for the run-speedtest action handler."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ops.pebble import ExecError
+
+from _speedtest import (
+    LIBRESPEED_BINARY_DEST,
+    _build_command,
+    _parse_output,
+    handle_speedtest,
+)
+
+SAMPLE_JSON = json.dumps(
+    [
+        {
+            "timestamp": "2026-04-27T19:02:59.554331101+02:00",
+            "server": {
+                "name": "Amsterdam, Netherlands (Clouvider)",
+                "url": "https://ams.speedtest.clouvider.net/backend",
+            },
+            "client": {"ip": "1.2.3.4"},
+            "bytes_sent": 35061760,
+            "bytes_received": 345601560,
+            "ping": 22.36,
+            "jitter": 1.49,
+            "upload": 50.07,
+            "download": 493.45,
+            "share": "",
+        }
+    ]
+)
+
+
+@pytest.fixture
+def event():
+    """Action event with default speedtest params."""
+    e = MagicMock()
+    e.params = {"duration": 15, "timeout": 30}
+    return e
+
+
+@pytest.fixture
+def container():
+    """Pebble container that can connect, with binary already present."""
+    c = MagicMock()
+    c.can_connect.return_value = True
+    c.exists.return_value = True
+    return c
+
+
+def _exec_returning(output: str) -> MagicMock:
+    """Build a MagicMock for container.exec(...) that yields `output` on wait_output()."""
+    process = MagicMock()
+    process.wait_output.return_value = (output, "")
+    return process
+
+
+def test_happy_path_maps_all_result_fields(event, container):
+    container.exec.return_value = _exec_returning(SAMPLE_JSON)
+
+    handle_speedtest(event, container)
+
+    event.set_results.assert_called_once_with(
+        {
+            "download-mbps": 493.45,
+            "upload-mbps": 50.07,
+            "ping-ms": 22.36,
+            "jitter-ms": 1.49,
+            "bytes-sent": 35061760,
+            "bytes-received": 345601560,
+            "server-name": "Amsterdam, Netherlands (Clouvider)",
+            "server-url": "https://ams.speedtest.clouvider.net/backend",
+        }
+    )
+    event.fail.assert_not_called()
+
+
+def test_fails_when_container_unreachable(event):
+    container = MagicMock()
+    container.can_connect.return_value = False
+
+    handle_speedtest(event, container)
+
+    event.fail.assert_called_once()
+    container.exec.assert_not_called()
+
+
+def test_pushes_binary_when_missing(event, container):
+    container.exists.return_value = False
+    container.exec.return_value = _exec_returning(SAMPLE_JSON)
+
+    with patch("_speedtest.LIBRESPEED_BINARY_SRC") as src:
+        src.open.return_value.__enter__.return_value = b"binary-bytes"
+        handle_speedtest(event, container)
+
+    container.push.assert_called_once()
+    args, kwargs = container.push.call_args
+    assert args[0] == LIBRESPEED_BINARY_DEST
+    assert kwargs["permissions"] == 0o755
+
+
+def test_skips_push_when_binary_present(event, container):
+    container.exec.return_value = _exec_returning(SAMPLE_JSON)
+
+    handle_speedtest(event, container)
+
+    container.push.assert_not_called()
+
+
+def test_fails_on_exec_error(event, container):
+    container.exec.return_value.wait_output.side_effect = ExecError(
+        command=[LIBRESPEED_BINARY_DEST], exit_code=1, stdout="", stderr="connection refused"
+    )
+
+    handle_speedtest(event, container)
+
+    event.fail.assert_called_once()
+    assert "connection refused" in event.fail.call_args.args[0]
+    event.set_results.assert_not_called()
+
+
+def test_fails_on_exec_timeout(event, container):
+    container.exec.return_value.wait_output.side_effect = TimeoutError()
+
+    handle_speedtest(event, container)
+
+    event.fail.assert_called_once()
+    assert "timed out" in event.fail.call_args.args[0]
+
+
+def test_fails_on_malformed_json(event, container):
+    container.exec.return_value = _exec_returning("not-json")
+
+    handle_speedtest(event, container)
+
+    event.fail.assert_called_once()
+    event.set_results.assert_not_called()
+
+
+def test_fails_on_empty_json_array(event, container):
+    container.exec.return_value = _exec_returning("[]")
+
+    handle_speedtest(event, container)
+
+    event.fail.assert_called_once()
+
+
+def test_command_includes_server_id_when_provided():
+    cmd = _build_command(server_id=42, duration=10, timeout=20)
+    assert "--server" in cmd
+    assert "42" in cmd
+    assert cmd[cmd.index("--server") + 1] == "42"
+    assert "--duration" in cmd and cmd[cmd.index("--duration") + 1] == "10"
+
+
+def test_command_omits_server_id_when_absent():
+    cmd = _build_command(server_id=None, duration=15, timeout=30)
+    assert "--server" not in cmd
+    assert "--no-icmp" in cmd
+    assert "--json" in cmd
+
+
+def test_parse_output_rejects_non_list():
+    with pytest.raises(ValueError):
+        _parse_output("{}")

--- a/docs/charms/vpn-gateway.md
+++ b/docs/charms/vpn-gateway.md
@@ -112,3 +112,32 @@ The charm requires:
 - **Cluster CIDRs** so internal traffic bypasses the VPN
 
 See [gluetun-k8s on Charmhub](https://charmhub.io/gluetun-k8s) for all options.
+
+### Actions
+
+#### `speedtest`
+
+Measure throughput through the active VPN tunnel using a bundled [librespeed-cli](https://github.com/librespeed/speedtest-cli) binary. The test runs inside the gluetun container, so all traffic traverses the VPN — useful for verifying the link or comparing servers.
+
+```bash
+juju run gluetun-k8s/0 speedtest --wait=3m
+```
+
+A typical run takes about 60 seconds (download phase + upload phase + setup), so set `--wait` to at least `2m`.
+
+**Parameters:**
+
+| Param       | Type | Default | Description                                                            |
+|-------------|------|---------|------------------------------------------------------------------------|
+| `server-id` | int  | _auto_  | Pin a specific [LibreSpeed server ID](https://librespeed.org/) — by default the closest server is auto-selected. |
+| `duration`  | int  | `15`    | Per-direction test duration in seconds.                                |
+| `timeout`   | int  | `30`    | HTTP request timeout in seconds.                                       |
+
+**Result keys:**
+
+- `download-mbps`, `upload-mbps` — throughput in megabits/sec
+- `ping-ms`, `jitter-ms` — latency to the test server
+- `bytes-sent`, `bytes-received` — raw byte counts
+- `server-name`, `server-url` — the server that was selected
+
+The action fails if the unit is not the leader, the charm is misconfigured, or the VPN is not connected (the kill switch would block the test anyway).


### PR DESCRIPTION
Closes #43

## What
Adds a `speedtest` Juju action to the gluetun charm that runs `speedtest-cli` from within the charm network namespace (i.e. through the VPN tunnel).

## Changes
- `src/_speedtest_action.py` — action handler using [`speedtest-cli`](https://github.com/librespeed/speedtest-cli) go binary
- `src/charm.py` — wires up `speedtest_action` → `_on_speedtest_action`
- `charmcraft.yaml` — `speedtest` action definition
- `tests/unit/test_speedtest_action.py` — 7 unit tests covering success, missing dep, network error, and result formatting

## Usage
```
juju run gluetun/0 speedtest --wait=3m
```